### PR TITLE
Changes to make gecos agent work in Xenial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.5
 
 Package: gecos-agent
 Architecture: all
-Depends: python (>= 2.6.6-3)
+Depends: python (>= 2.6.6-3), python-notify
 Breaks: gecosws-firstart, gecosws-chef-snitch, gecosws-chef-notifier-cinnamon
 Replaces: gecosws-firstart, gecosws-chef-snitch, gecosws-chef-notifier-cinnamon
 Description: GECOS Agent for workstations

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,3 +5,7 @@ LINE='ALL ALL=NOPASSWD: /usr/bin/gecos-chef-client-wrapper'
 FILE=/etc/sudoers
 
 grep -q "$LINE" "$FILE" || echo "$LINE" >> "$FILE" 
+
+# Set the services to start at boot
+systemctl enable gecos-snitch-service.service
+systemctl enable gecos-first-login.service

--- a/debian/postrm
+++ b/debian/postrm
@@ -7,3 +7,6 @@ TMPFILE=/etc/sudoers.new
 
 grep -v $PATTERN $FILE > $TMPFILE
 mv $TMPFILE $FILE
+
+systemctl disable gecos-snitch-service.service
+systemctl disable gecos-first-login.service

--- a/lib/systemd/system/gecos-first-login.service
+++ b/lib/systemd/system/gecos-first-login.service
@@ -1,0 +1,30 @@
+# gecos-first-login dbus service
+#
+# init gecos-first-login dbus service Systemd configuration file
+#
+# Copyright (C) 2016 Junta de Andalucia. <http://www.juntadeandalucia.es/>
+#
+# This software is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this package; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+[Unit]
+Description=GECOS First Login Service
+After=display-manager.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/gecos-first-login-dbusservice > /tmp/gecos-first-login-dbus-service.log 2>&1
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/systemd/system/gecos-snitch-service.service
+++ b/lib/systemd/system/gecos-snitch-service.service
@@ -1,0 +1,30 @@
+# gecosws-chef-snitch
+#
+# init gecosws-chef-snitch service Systemd configuration file
+#
+# Copyright (C) 2016 Junta de Andalucia. <http://www.juntadeandalucia.es/>
+#
+# This software is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this package; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+[Unit]
+Description=GECOS Snitch Service
+After=network-manager.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/gecos-snitch-service
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='gecos-agent',
                   ('/usr/share/gecos-first-login/media',glob.glob('data/media/*')),
                   ('/etc/dbus-1/system.d/',glob.glob('etc/dbus-1/system.d/*.conf')),
                   ('/etc/init/',glob.glob('etc/init/*.conf')),
+                  ('/lib/systemd/system/',glob.glob('lib/systemd/system/*.service')),
                   ('/etc/xdg/autostart/',glob.glob('etc/xdg/autostart/*.desktop'))]
      )
 


### PR DESCRIPTION
Added "systemd" services ("systemd" is a replacement for "upstart"), and added "python-notify" as a dependence (needed by "gecos-snitch-systray".
