### PR TITLE
Overwrite "HOME" environment variable.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -12,13 +12,3 @@ systemctl enable gecos-first-login.service
 
 # Disable chef client service
 systemctl disable chef-client.service
-
-# Enforce /home/* directories security
-# set directories permissions to 0700 
-# set files permissions to 0600
-sed -i 's/^UMASK.*/UMASK\t\t077/' /etc/login.defs
-sed -i 's/^USERGROUPS_ENAB yes/USERGROUPS_ENAB no/' /etc/login.defs
-sed -i 's/^DIR_MODE=0755/DIR_MODE=0700/' /etc/adduser.conf
-
-find /etc/skel -type f -exec chmod 600 \{\} \;
-find /etc/skel -type d -exec chmod 700 \{\} \;

--- a/debian/postinst
+++ b/debian/postinst
@@ -12,3 +12,13 @@ systemctl enable gecos-first-login.service
 
 # Disable chef client service
 systemctl disable chef-client.service
+
+# Enforce /home/* directories security
+# set directories permissions to 0700 
+# set files permissions to 0600
+sed -i 's/^UMASK.*/UMASK\t\t077/' /etc/login.defs
+sed -i 's/^USERGROUPS_ENAB yes/USERGROUPS_ENAB no/' /etc/login.defs
+sed -i 's/^DIR_MODE=0755/DIR_MODE=0700/' /etc/adduser.conf
+
+find /etc/skel -type f -exec chmod 600 \{\} \;
+find /etc/skel -type d -exec chmod 700 \{\} \;

--- a/scripts/gecos-chef-client-wrapper
+++ b/scripts/gecos-chef-client-wrapper
@@ -14,6 +14,7 @@ import random
 import re
 
 if __name__ == '__main__':
+    os.environ["HOME"] = "/root"
     fp = open('/tmp/gecos-chef-client-wrapper.log', "w")
     args = sys.argv
     args.pop(0)


### PR DESCRIPTION
Since "gecos-chef-client-wrapper" is run with "sudo" command, we must overwrite the "HOME" environment variable because by default is the path to the sudoer user "home" directory:

```
 $ sudo env | grep HOME 
 HOME=/home/myuser
```

This incorrect "HOME" environment variable causes that some configuration files and folders are created with the "root" user inside the user "home" directory.

For example, if initialy the "/home/myuser/.mozilla" folder does not exists, may be created by simply running a command to show the Firefox version:

```
$ sudo firefox -v
Mozilla Firefox 45.7.0
$ ls -la /home/myuser | grep mozilla
drwx------  3 root    root    4096 feb 20 16:29 .mozilla
```

